### PR TITLE
update to work with bevy main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,7 @@ keywords = ["gamedev", "graphics", "bevy", "3d", "bounding"]
 categories = ["game-engines", "rendering"]
 
 [dependencies]
-bevy = { version = "0.5", default-features = false, features = ["render"] }
-#bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["render"] }
-
-[features]
-ex = ["bevy/bevy_wgpu", "bevy/bevy_winit", "bevy/bevy_gltf", "bevy/x11"]
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = "0.5" }
 
 [[example]]
 name = "demo"
-required-features = ["ex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Bounding box generation for the Bevy Engine."
 repository = "https://github.com/aevyrie/bevy_mod_bounding/"
 keywords = ["gamedev", "graphics", "bevy", "3d", "bounding"]
 categories = ["game-engines", "rendering"]
+resolver = "2"
 
 [dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = "0.5" }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_mod_bounding::{aabb, debug, obb, *};
 
 fn main() {
-    App::build()
+    App::new()
         .insert_resource(Msaa { samples: 2 })
         .add_plugins(DefaultPlugins)
         .add_plugin(BoundingVolumePlugin::<sphere::BSphere>::default())
@@ -13,6 +13,7 @@ fn main() {
         .run();
 }
 
+#[derive(Component)]
 struct Rotator;
 
 fn setup(
@@ -61,7 +62,7 @@ fn setup(
         .insert(debug::DebugBounds)
         .insert(Rotator);
     // Light
-    commands.spawn_bundle(LightBundle {
+    commands.spawn_bundle(PointLightBundle {
         transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
         ..Default::default()
     });

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -8,7 +8,7 @@ use core::panic;
 /// Defines an axis-aligned bounding box in mesh space - that is - the bounding box is located at
 /// the mesh's origin, but the current [GlobalTransform] has been used to rotate and scale the mesh
 /// to compute a valid AABB. This reduces float error when the mesh is located far from the origin.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Component)]
 pub struct Aabb {
     /// The coordinates of the point located at the minimum x, y, and z coordinate. This can also
     /// be thought of as the length of the -x, -y, -z axes that extend from the origin and touch
@@ -98,7 +98,7 @@ impl BoundingVolume for Aabb {
         let vertices: Vec<Vec3> = match mesh.attribute(Mesh::ATTRIBUTE_POSITION) {
             None => panic!("Mesh does not contain vertex positions"),
             Some(vertex_values) => match &vertex_values {
-                VertexAttributeValues::Float3(positions) => positions
+                VertexAttributeValues::Float32x3(positions) => positions
                     .iter()
                     .map(|coordinates| transform_matrix.transform_point3(Vec3::from(*coordinates)))
                     .collect(),
@@ -117,7 +117,7 @@ impl BoundingVolume for Aabb {
         match mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION) {
             None => panic!("Mesh does not contain vertex positions"),
             Some(vertex_values) => match vertex_values {
-                VertexAttributeValues::Float3(ref mut positions) => {
+                VertexAttributeValues::Float32x3(ref mut positions) => {
                     *positions = positions
                         .iter()
                         .map(|coordinates| {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,9 +5,11 @@ use bevy::{
 };
 
 /// Marks an entity that should have a mesh added as a child to represent the mesh's bounding volume.
+#[derive(Component)]
 pub struct DebugBounds;
 
 /// Marks the debug bounding volume mesh, which exists as a child of a [BoundingVolumeDebug] entity
+#[derive(Component)]
 pub struct DebugBoundsMesh;
 
 /// Updates existing debug meshes, and creates new debug meshes on entities with a bounding volume
@@ -23,7 +25,7 @@ pub fn update_debug_meshes<T>(
     >,
     mut debug_mesh_query: Query<&mut Handle<Mesh>, With<DebugBoundsMesh>>,
 ) where
-    T: 'static + BoundingVolume + Clone + Send + Sync + std::fmt::Debug,
+    T: 'static + BoundingVolume + Clone + Send + Sync + std::fmt::Debug + Component,
     Mesh: From<&'static T>,
 {
     for (transform, bound_vol, entity, optional_children) in query.iter() {
@@ -62,11 +64,11 @@ pub fn update_debug_meshes<T>(
 #[allow(clippy::type_complexity)]
 pub fn update_debug_mesh_visibility<T>(
     mut query: QuerySet<(
-        Query<(&Children, &Visible), (With<DebugBounds>, With<T>, Changed<Visible>)>,
-        Query<&mut Visible, With<DebugBoundsMesh>>,
+        QueryState<(&Children, &Visible), (With<DebugBounds>, With<T>, Changed<Visible>)>,
+        QueryState<&mut Visible, With<DebugBoundsMesh>>,
     )>,
 ) where
-    T: 'static + BoundingVolume + Clone + Send + Sync,
+    T: 'static + BoundingVolume + Clone + Send + Sync + Component,
 {
     let child_list: Vec<(Box<Children>, bool)> = query
         .q0()
@@ -75,7 +77,7 @@ pub fn update_debug_mesh_visibility<T>(
         .collect();
     for (children, parent_visible) in child_list.iter() {
         for child in children.iter() {
-            if let Ok(mut child_visible) = query.q1_mut().get_mut(*child) {
+            if let Ok(mut child_visible) = query.q1().get_mut(*child) {
                 child_visible.is_visible = *parent_visible;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@ pub struct BoundingVolumePlugin<T: BoundingVolume> {
 /// A plugin that provides functionality for generating and updating bounding volumes for meshes.
 impl<T> Plugin for BoundingVolumePlugin<T>
 where
-    T: 'static + Send + Sync + BoundingVolume + Clone + Debug,
+    T: 'static + Send + Sync + BoundingVolume + Clone + Debug + Component,
     Mesh: From<&'static T>,
 {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         app.add_system_to_stage(CoreStage::PreUpdate, spawn::<T>.system())
             .add_system_to_stage(
                 CoreStage::PostUpdate,
@@ -57,7 +57,7 @@ where
 /// the aforementioned mesh has loaded and can be read. This ensures that bounding volume
 /// components are always valid when queried, and at worst case can only be out of date if queried
 /// in a frame before the bounding volume update system is run.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Component)]
 pub struct Bounded<T: BoundingVolume + Send + Sync>(PhantomData<T>);
 
 impl<T: BoundingVolume + Send + Sync> Default for Bounded<T> {
@@ -97,7 +97,7 @@ pub trait BoundingVolume {
 /// entity. This new BoundingVolume is fully initialized and will be kept up to date with the
 /// `update()` system.
 #[allow(clippy::type_complexity)]
-pub fn spawn<T: 'static + BoundingVolume + Send + Sync + Debug>(
+pub fn spawn<T: 'static + BoundingVolume + Send + Sync + Debug + Component>(
     mut commands: Commands,
     meshes: Res<Assets<Mesh>>,
     query: Query<(&Handle<Mesh>, &GlobalTransform, Entity), With<Bounded<T>>>,
@@ -117,7 +117,7 @@ pub fn spawn<T: 'static + BoundingVolume + Send + Sync + Debug>(
 /// Updates [BoundingVolume]s when their meshes or [GlobalTransform]s are changed. If an entity's
 /// mesh has changed, triggering a bounding volume update, the update function will won't update it
 /// a second time if the transform has also changed.
-fn update<T: 'static + BoundingVolume + Send + Sync>(
+fn update<T: 'static + BoundingVolume + Send + Sync + Component>(
     meshes: Res<Assets<Mesh>>,
     changed_mesh_query: Query<Entity, Changed<Handle<Mesh>>>,
     changed_transform_query: Query<Entity, Changed<GlobalTransform>>,

--- a/src/obb.rs
+++ b/src/obb.rs
@@ -19,7 +19,7 @@ use std::{convert::TryInto, f32::consts::PI};
 /// the volume of the bounding box. The properties are stored in mesh space to minimize rounding
 /// error, and make it easy to defer recomputing the bounding volume until the mesh itself is
 /// changed.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Component)]
 pub struct Obb {
     aabb: Aabb,
     /// The orientation of the mesh that minimizes the AABB.
@@ -112,7 +112,7 @@ impl BoundingVolume for Obb {
         let vertices: Vec<Vec3> = match mesh.attribute(Mesh::ATTRIBUTE_POSITION) {
             None => panic!("Mesh does not contain vertex positions"),
             Some(vertex_values) => match &vertex_values {
-                VertexAttributeValues::Float3(positions) => positions
+                VertexAttributeValues::Float32x3(positions) => positions
                     .iter()
                     .map(|coordinates| Vec3::from(*coordinates))
                     .collect(),

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -6,7 +6,7 @@ use bevy::{
 use core::panic;
 
 /// Defines a bounding sphere with a radius and an origin at the center.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Component)]
 pub struct BSphere {
     /// Origin of the sphere in mesh space. The intent is that the bounding volume will be queried
     /// along with its [GlobalTransform], so the origin of the sphere will be transformed to the
@@ -46,7 +46,7 @@ impl BoundingVolume for BSphere {
         let vertices: Vec<Vec3> = match mesh.attribute(Mesh::ATTRIBUTE_POSITION) {
             None => panic!("Mesh does not contain vertex positions"),
             Some(vertex_values) => match &vertex_values {
-                VertexAttributeValues::Float3(positions) => positions
+                VertexAttributeValues::Float32x3(positions) => positions
                     .iter()
                     .map(|coordinates| Vec3::from(*coordinates))
                     .collect(),
@@ -112,7 +112,7 @@ impl BoundingVolume for BSphere {
         match mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION) {
             None => panic!("Mesh does not contain vertex positions"),
             Some(vertex_values) => match vertex_values {
-                VertexAttributeValues::Float3(ref mut positions) => {
+                VertexAttributeValues::Float32x3(ref mut positions) => {
                     *positions = positions
                         .iter()
                         .map(|coordinates| {


### PR DESCRIPTION
Hello,

I did a quick n dirty update of this plugin to get it to run with `bevy` `main`, mostly adding `Component` to trait bounds throughout. This plugin was quite handy for me.

Let me know if anything jumps out and I will fix it up.

Thanks